### PR TITLE
商品購入後、再購入できない様にする

### DIFF
--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -73,7 +73,10 @@
           この商品を削除する
       - else
         - if user_signed_in?
-          = link_to "購入画面に進む", buy_confirmation_path , class: "item-container__buy-btn"
+          - if @item.buyer_id.present?
+            = link_to "戻る",root_path, class: "item-container__buy-btn"
+          - else
+            = link_to "購入画面に進む", buy_confirmation_path , class: "item-container__buy-btn"
         - else
           =link_to "戻る", root_path , class: "item-container__buy-btn" 
       .item-container__explanation


### PR DESCRIPTION
What
商品購入後、再購入できない様にする

Why
２重払いを防ぐため
