### PR TITLE
画像差し替え機能

### DIFF
--- a/app/assets/javascripts/items_new.js
+++ b/app/assets/javascripts/items_new.js
@@ -102,6 +102,13 @@ $(document).on('turbolinks:load', function(){
       }
     });
 
+    // 画像の削除
+    $(document).on('click', '.delete-box', function() {
+      setLabel();
+      var index = $(this).attr('id').replace(/[^0-9]/g, '');
+      deleteImage(index);
+    });
+
     });
   });
 });

--- a/app/assets/javascripts/items_new.js
+++ b/app/assets/javascripts/items_new.js
@@ -1,13 +1,13 @@
 $(document).on('turbolinks:load', function(){
   $(function(){
 
-    function buildHTML(count) {
-      var html = `<div class="preview-box" id="preview-box__${count}">
+    function buildHTML(index) {
+      var html = `<div class="preview-box" id="preview-box__${index}">
                     <div class="upper-box">
                       <img src="" alt="preview">
                     </div>
                     <div class="lower-box">
-                      <div class="delete-box" id="delete_btn_${count}">
+                      <div class="delete-box" id="delete_btn_${index}">
                         <span>削除</span>
                       </div>
                     </div>
@@ -82,17 +82,17 @@ $(document).on('turbolinks:load', function(){
           $('.label-content').show();
         }
         setLabel(count);
-        if(id < 5){
-          $('.label-box').attr({id: `label-box--${id}`,for: `item_images_attributes_${id}_image`});
+        if(index < 5){
+          $('.label-box').attr({index: `label-box--${index}`,for: `item_images_attributes_${index}_image`});
         }
       } else {
-        $(`#item_images_attributes_${id}__destroy`).prop('checked',true);
+        $(`#item_images_attributes_${index}__destroy`).prop('checked',true);
         if (count == 4) {
           $('.label-content').show();
         }
         setLabel();
-        if(id < 5){
-          $('.label-box').attr({id: `label-box--${id}`,for: `item_images_attributes_${id}_image`});
+        if(index < 5){
+          $('.label-box').attr({id: `label-box--${index}`,for: `item_images_attributes_${index}_image`});
         }
       }
     });

--- a/app/assets/javascripts/items_new.js
+++ b/app/assets/javascripts/items_new.js
@@ -7,6 +7,11 @@ $(document).on('turbolinks:load', function(){
                       <img src="" alt="preview">
                     </div>
                     <div class="lower-box">
+                      <div class="edit-box" id="edit-btn-${index}">
+                        <div class="edit-btn">
+                          <span>編集</span>
+                        </div>
+                      </div>
                       <div class="delete-box" id="delete_btn_${index}">
                         <span>削除</span>
                       </div>

--- a/app/assets/javascripts/items_new.js
+++ b/app/assets/javascripts/items_new.js
@@ -42,51 +42,15 @@ $(document).on('turbolinks:load', function(){
       $('.label-content').css('width', labelWidth);
     }
 
-    // プレビューの追加
-    $(document).on('change', '.hidden-field', function() {
-      setLabel();
-      var id = $(this).attr('id').replace(/[^0-9]/g, '');
-      $('.label-box').attr({id: `label-box--${id}`,for: `item_images_attributes_${id}_image`});
-      var file = this.files[0];
-      var reader = new FileReader();
-      reader.readAsDataURL(file);
-      reader.onload = function() {
-        var image = this.result;
-        if ($(`#preview-box__${id}`).length == 0) {
-          var count = $('.preview-box').length;
-          var html = buildHTML(id);
-          var prevContent = $('.label-content').prev();
-          $(prevContent).append(html);
-        }
-        $(`#preview-box__${id} img`).attr('src', `${image}`);
-        var count = $('.preview-box').length;
-        if (count == 5) {
-          $('.label-content').hide();
-        }
-        if ($(`#item_images_attributes_${id}__destroy`)){
-          $(`#item_images_attributes_${id}__destroy`).prop('checked',false);
-        } 
-        setLabel();
-        if(count < 5){
-          $('.label-box').attr({id: `label-box--${count}`,for: `item_images_attributes_${count}_image`});
-        }
-      }
-    });
-
-    // 画像の削除
-    $(document).on('click', '.delete-box', function() {
-      var count = $('.preview-box').length;
-      setLabel(count);
-      var id = $(this).attr('id').replace(/[^0-9]/g, '');
-      $(`#preview-box__${id}`).remove();
-
-      if ($(`#item_images_attributes_${id}__destroy`).length == 0) {
-        $(`#item_images_attributes_${id}_image`).val("");
+    function deleteImage(index) {
+      $(`#preview-box__${index}`).remove();
+      if ($(`#item_images_attributes_${index}__destroy`).length == 0) {
+        $(`#item_images_attributes_${index}_image`).val("");
         var count = $('.preview-box').length;
         if (count == 4) {
           $('.label-content').show();
         }
-        setLabel(count);
+        setLabel();
         if(index < 5){
           $('.label-box').attr({index: `label-box--${index}`,for: `item_images_attributes_${index}_image`});
         }
@@ -100,6 +64,44 @@ $(document).on('turbolinks:load', function(){
           $('.label-box').attr({id: `label-box--${index}`,for: `item_images_attributes_${index}_image`});
         }
       }
+    }
+
+    // プレビューの追加
+    $(document).on('change', '.hidden-field', function() {
+      setLabel();
+      var index = $(this).attr('id').replace(/[^0-9]/g, '');
+      var file = this.files[0];
+      if (file != undefined) {
+        $('.label-box').attr({id: `label-box--${index}`,for: `item_images_attributes_${index}_image`});
+        var reader = new FileReader();
+        reader.readAsDataURL(file);
+        reader.onload = function() {
+          var image = this.result;
+          if ($(`#preview-box__${index}`).length == 0) {
+            var count = $('.preview-box').length;
+            var html = buildHTML(index);
+            var prevContent = $('.label-content').prev();
+            $(prevContent).append(html);
+          }
+          $(`#preview-box__${index} img`).attr('src', `${image}`);
+          var count = $('.preview-box').length;
+          if (count == 5) {
+            $('.label-content').hide();
+          }
+          if ($(`#item_images_attributes_${index}__destroy`)){
+            $(`#item_images_attributes_${index}__destroy`).prop('checked',false);
+          } 
+          setLabel();
+          if(count < 5){
+            $('.label-box').attr({index: `label-box--${count}`,for: `item_images_attributes_${count}_image`});
+          }
+        }
+      }
+      else {
+        deleteImage(index);
+      }
+    });
+
     });
   });
 });

--- a/app/assets/javascripts/items_new.js
+++ b/app/assets/javascripts/items_new.js
@@ -109,6 +109,10 @@ $(document).on('turbolinks:load', function(){
       deleteImage(index);
     });
 
+    //画像の差し替え
+    $(document).on('click','.edit-box', function() {
+      var index = $(this).attr('id').replace(/[^0-9]/g, '');
+      $(`#item_images_attributes_${index}_image`).click();
     });
   });
 });

--- a/app/assets/stylesheets/items/_new.scss
+++ b/app/assets/stylesheets/items/_new.scss
@@ -79,9 +79,18 @@
             .lower-box {
               display: flex;
               text-align: center;
+              .edit-box {
+                color: #00b0ff;
+                width: 50%;
+                height: 50px;
+                line-height: 50px;
+                border: 1px solid #eee;
+                background: #f5f5f5;
+                cursor: pointer;
+              }
               .delete-box {
                 color: #00b0ff;
-                width: 100%;
+                width: 50%;
                 height: 50px;
                 line-height: 50px;
                 border: 1px solid #eee;

--- a/app/views/items/edit.html.haml
+++ b/app/views/items/edit.html.haml
@@ -17,6 +17,9 @@
                   .upper-box
                     = image_tag image.image.url, width: "112", height: "112", alt: "preview"
                   .lower-box
+                    .edit-box{id: "edit-btn-#{index}"}
+                      .edit-btn
+                        %span 編集
                     .delete-box
                       .delete-btn{data: {delete: {id: index}}}
                         %span 削除


### PR DESCRIPTION
### What
商品出品・編集で画像の差し替え機能実装
### Why
削除して追加をするよりも口数を減らせるから
削除、追加で入れ替えるとimagesの中身の順番が入れ替わってしまうから必要となる
[![Image from Gyazo](https://i.gyazo.com/bb66b91ff3d6a6730eb04fc074b18bc7.gif)](https://gyazo.com/bb66b91ff3d6a6730eb04fc074b18bc7)